### PR TITLE
Added image preloading for basic images

### DIFF
--- a/src/SmallsOnline.Web.PublicSite/wwwroot/index.html
+++ b/src/SmallsOnline.Web.PublicSite/wwwroot/index.html
@@ -60,6 +60,13 @@
                     </div>
                 </div>
             </div>
+            <div class="row d-none">
+                <div class="col">
+                    <img src="https://cdn.smalls.online/images/site/smalls_animal-crossing.webp" preload />
+                    <img src="https://cdn.smalls.online/images/site/me.jpg" preload />
+                    <img src="https://cdn.smalls.online/images/site/me_dumb.jpg" preload />
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Instead of waiting until the UI is loaded, the main base images (Like my
picture and my logo) are loaded in during the initial page load. This
will help prevent the images from suddenly appearing once the UI is
loaded.
