### PR TITLE
Add dark mode

### DIFF
--- a/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-custom.css
+++ b/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-custom.css
@@ -1,0 +1,33 @@
+:root {
+    --bs-dark-bg: #495057;
+    --bs-dark-text: #e9ecef;
+    --bs-dark-text-muted: #adb5bd;
+    --bs-dark-link: #b6d2fc;
+    --bs-dark-link-hover: #85b4f9;
+    --bs-list-group-item-border: #f2f2f2;
+}
+
+@media (prefers-color-scheme: dark) {
+    .card {
+        background-color: var(--bs-dark-bg);
+        color: var(--bs-dark-text);
+    }
+
+    .list-group-item {
+        background-color: var(--bs-dark-bg);
+        color: var(--bs-dark-text);
+        border: 1px solid rgba(233, 236, 239, 0.125);
+    }
+
+    .text-muted {
+        color: var(--bs-dark-text-muted)!important;
+    }
+
+    a {
+        color: var(--bs-dark-link);
+    }
+
+    a:hover {
+        color: var(--bs-dark-link-hover);
+    }
+}

--- a/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-custom.css
+++ b/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-custom.css
@@ -13,6 +13,14 @@
         color: var(--bs-dark-text);
     }
 
+    .card-header {
+        background-color: rgba(0, 0, 0, .3)
+    }
+
+    .card-footer {
+        background-color: rgba(0, 0, 0, .3)
+    }
+
     .list-group-item {
         background-color: var(--bs-dark-bg);
         color: var(--bs-dark-text);

--- a/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-icons-custom.css
+++ b/src/SmallsOnline.Web.PublicSite/wwwroot/css/bootstrap-icons-custom.css
@@ -2,16 +2,28 @@
     font-size: 2em;
 }
 
-.bi-linkedin-color {
-    color: #006192;
+@media (prefers-color-scheme: light) {
+    .bi-linkedin-color {
+        color: #006192;
+    }
+
+    .bi-github-color {
+        color: #333333;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    .bi-linkedin-color {
+        color: #0099e6;
+    }
+
+    .bi-github-color {
+        color: #bebfc1;
+    }
 }
 
 .bi-twitter-color {
     color: #55ACEE;
-}
-
-.bi-github-color {
-    color: #333333;
 }
 
 .bi-icon-color-gold {

--- a/src/SmallsOnline.Web.PublicSite/wwwroot/index.html
+++ b/src/SmallsOnline.Web.PublicSite/wwwroot/index.html
@@ -23,6 +23,7 @@
     <link href="css/bootstrap/bootstrap.trimmed.css" rel="stylesheet" />
     <link href="css/bootstrap-icons/bootstrap-icons.trimmed.css" rel="stylesheet" />
     <link href="css/bootstrap-icons-custom.css" rel="stylesheet" />
+    <link href="css/bootstrap-custom.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="css/animation/animation.css" rel="stylesheet" />
     <link href="SmallsOnline.Web.PublicSite.styles.css" rel="stylesheet" />


### PR DESCRIPTION
Adding dark mode support to the website (Based off the device's current system setting).

Light mode:
![Website light mode example](https://user-images.githubusercontent.com/1042907/178313442-bae7803c-62b2-436f-9037-297f0fbec073.png)

![Website dark mode example](https://user-images.githubusercontent.com/1042907/178313562-4d04e359-cb42-4f8e-8b76-26bd3797333b.png)
