### PR TITLE
Added roll forward config setting

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.302"
+    "version": "6.0.302",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Setting rollForward to 'latestFeature' to ensure all .NET 6.0.x SDKs are usable after .NET 6.0.302.