### PR TITLE
[Bug fix] Fix transition animations

### DIFF
--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/AboutMe.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/AboutMe.razor.cs
@@ -5,6 +5,6 @@ namespace SmallsOnline.Web.PublicSite.Client;
 /// </summary>
 public partial class AboutMe : ComponentBase
 {
-    [CascadingParameter]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 }

--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/BlogEntryPage.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/BlogEntryPage.razor.cs
@@ -24,7 +24,7 @@ public partial class BlogEntryPage : ComponentBase, IDisposable
     [Parameter]
     public string Id { get; set; } = null!;
 
-    [CascadingParameter]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 
     private bool _isFinishedLoading = false;

--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/BlogListPage.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/BlogListPage.razor.cs
@@ -20,7 +20,7 @@ public partial class BlogListPage : ComponentBase, IDisposable
     [Parameter]
     public int PageNumber { get; set; } = 1;
 
-    [CascadingParameter]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 
     private bool _isFinishedLoading = false;

--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/FavoritesOf.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/FavoritesOf.razor.cs
@@ -22,7 +22,7 @@ public partial class FavoritesOf : ComponentBase, IDisposable
     [Parameter]
     public string? ListYear { get; set; }
 
-    [CascadingParameter]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 
     private bool _isFinishedLoading = false;

--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/Home.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/Home.razor.cs
@@ -10,6 +10,6 @@ public partial class Home : ComponentBase
     [Inject]
     protected ILogger<Home> PageLogger { get; set; } = null!;
 
-    [CascadingParameter()]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 }

--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/Projects.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/Projects.razor.cs
@@ -12,7 +12,7 @@ public partial class Projects : ComponentBase
     [Inject]
     protected IHttpClientFactory HttpClientFactory { get; set; } = null!;
 
-    [CascadingParameter]
+    [CascadingParameter(Name = "ShouldFadeSlideIn")]
     protected ShouldFadeIn? ShouldFadeSlideIn { get; set; }
 
     private List<ProjectItem>? _projectItems;

--- a/src/SmallsOnline.Web.PublicSite/Client/Shared/MainLayout.razor
+++ b/src/SmallsOnline.Web.PublicSite/Client/Shared/MainLayout.razor
@@ -12,7 +12,7 @@
         <div class="container-fluid">
             <div class="row py-3 justify-content-center">
                 <div class="col-md-12 col-lg-9 col-xl-7 col-xxl-6">
-                    <CascadingValue Name="ShouldFadeSlideIn" Value="@_shouldFadeSlideIn" IsFixed=false>
+                    <CascadingValue Name="ShouldFadeSlideIn" Value="@_shouldFadeSlideIn">
                         @Body
                     </CascadingValue>
                 </div>

--- a/src/SmallsOnline.Web.PublicSite/Client/Shared/MainLayout.razor.cs
+++ b/src/SmallsOnline.Web.PublicSite/Client/Shared/MainLayout.razor.cs
@@ -17,7 +17,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
 
     private IJSObjectReference? _mainLayoutJSModule;
     private ShouldFadeIn _shouldFadeSlideIn = new();
-    private bool _isEnableFadeSlideALocationChangeEventMethod;
+    private bool _isEnableFadeSlideInOnLocationChangeEventMethod;
     private readonly Regex _anchorTagRegex = new("^(?>https|http):\\/\\/.+?\\/.*(?'anchorTag'#(?'anchorTagName'.+))$");
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -27,7 +27,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
             _mainLayoutJSModule = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./Shared/MainLayout.razor.js");
 
             NavigationManager.LocationChanged += EnableFadeSlideInOnPageChange;
-            _isEnableFadeSlideALocationChangeEventMethod = true;
+            _isEnableFadeSlideInOnLocationChangeEventMethod = true;
 
             await ScrollToAnchorAsync(NavigationManager.Uri);
         }
@@ -47,7 +47,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
         _shouldFadeSlideIn.Enabled = true;
         StateHasChanged();
         NavigationManager.LocationChanged -= EnableFadeSlideInOnPageChange;
-        _isEnableFadeSlideALocationChangeEventMethod = false;
+        _isEnableFadeSlideInOnLocationChangeEventMethod = false;
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public partial class MainLayout : LayoutComponentBase, IDisposable
     {
         if (disposing)
         {
-            if (_isEnableFadeSlideALocationChangeEventMethod)
+            if (_isEnableFadeSlideInOnLocationChangeEventMethod)
             {
                 NavigationManager.LocationChanged -= EnableFadeSlideInOnPageChange;
             }


### PR DESCRIPTION
This fixes an issue where transition animations weren't being enabled on page changes. The flag for enabling the animations wasn't being passed down from `MainLayout` to the pages.

On the pages themselves, the `[CascadingParameter]` attribute has been explicitly defined to the name _ShouldFadeSlideIn_.