### PR TITLE
[Update] Remove intro text for album on 'Favorites of'

### DIFF
--- a/src/SmallsOnline.Web.PublicSite/Client/Pages/FavoritesOf.razor
+++ b/src/SmallsOnline.Web.PublicSite/Client/Pages/FavoritesOf.razor
@@ -103,9 +103,6 @@ else
                         <div class="row">
                             <div class="col">
                                 <p class="text-muted font-weight-bold">
-                                    This list is in no particular order, with the exception of the first entry.
-                                </p>
-                                <p class="text-muted font-weight-bold">
                                     <i class="bi bi-star-fill bi-icon-color-gold" /> - This icon means that this is what I
                                     consider to
                                     be my personal <span class="font-italic">album of the year</span>.


### PR DESCRIPTION
Removing the intro text for albums, since it can be a little confusing. Especially as the year goes on and the first entry is just the first album that was released during the year.